### PR TITLE
Fix makefiles for listings chap5/libso and chap5/libso_main.

### DIFF
--- a/listings/chap5/libso/Makefile
+++ b/listings/chap5/libso/Makefile
@@ -9,10 +9,10 @@ libso.o: libso.asm
 	nasm $(AFLAGS) -o libso.o libso.asm
 
 libso.so: libso.o
-	ld -shared -o libso.so libso.o --dynamic-linker=/lib64/ld-linux-x86-64.so.2
+	ld -shared -o libso.so libso.o
 
 main: main.o libso.so
-	ld -o main main.o -d libso.so 	
+	ld -o main main.o -d libso.so --dynamic-linker=/lib64/ld-linux-x86-64.so.2
 
 clean: 
 	rm -f main.o libso.o libso.so main

--- a/listings/chap5/libso_main/Makefile
+++ b/listings/chap5/libso_main/Makefile
@@ -12,7 +12,7 @@ libso.so: libso.o
 	ld -shared -o libso.so libso.o
 
 main: main.o libso.so
-	ld -o main main.o -d libso.so 	
+	ld -o main main.o -d libso.so --dynamic-linker=/lib64/ld-linux-x86-64.so.2
 
 clean: 
 	rm -f main.o libso.o libso.so main


### PR DESCRIPTION
Same fix that was done to the chap5/libso listing in 3cc67df78b6b699faabd044e99b56bd88a5488b8 applied to the related makefiles.