### PR TITLE
changed loop termination logic to avoid Segmentation fault

### DIFF
--- a/listings/chap16/stack_unwind/stack_unwind.asm
+++ b/listings/chap16/stack_unwind/stack_unwind.asm
@@ -1,4 +1,5 @@
 extern printf
+extern fptr ; pointer to local variable of main
 global unwind
 
 section .rodata
@@ -6,15 +7,15 @@ format : db "%x ", 10, 0
 
 section .code
 unwind:
-push rbx
+    push rbx
 
-; while (rbx != 0) { 
+; while (rbx > fptr) { 
     ;     print rbx; rbx = [rbx];
     ; }
     mov rbx, rbp 
     .loop:
-    test rbx, rbx
-    jz .end
+    cmp rbx,fptr ; check if pointing fptr or lower
+    jc .end
     mov rdi, format
     mov rsi, rbx
     call printf

--- a/listings/chap16/stack_unwind/stack_unwind.c
+++ b/listings/chap16/stack_unwind/stack_unwind.c
@@ -1,7 +1,10 @@
 void unwind();
+int *fptr; /* global pointer to a local variable of main */
 void f( int count ) {
     if ( count ) f( count-1 ); else unwind(); 
 }
 int main(void) {
+    int filler=0; /* make a local variable of main */
+    fptr=&filler; /* set up a global pointer for unwind */
     f( 10 ); return 0;
 }


### PR DESCRIPTION
I found that the original logic in` listings/chap16/stack_unwind` did not work in my environment. 
Here is the screen shot on my flickr album: https://flic.kr/p/ZG3FFQ
The loop did not stopped before accessing an invalid address.
So I changed the loop termination logic in the assembly module. 
As the original check (seeing if `rbx` register is not zero) did not work in my case, I made a global pointer to a local variable in `main` and modified the loop termination check to see that `rbx` is not below the address of the local variable of `main`. It does work in my environment (Linux kneo-PC-VG30VVZGM 4.4.0-97-generic #120-Ubuntu SMP Tue Sep 19 17:28:18 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux)