### PR TITLE
Modified Listing 16-2 stack_unwind.asm to fix ld errors when linking

### DIFF
--- a/listings/chap16/stack_unwind/stack_unwind.asm
+++ b/listings/chap16/stack_unwind/stack_unwind.asm
@@ -9,16 +9,16 @@ section .code
 unwind:
     push rbx
 
-; while (rbx > fptr) { 
+    ; while (rbx > fptr) { 
     ;     print rbx; rbx = [rbx];
     ; }
     mov rbx, rbp 
     .loop:
-    cmp rbx,fptr ; check if pointing fptr or lower
+    cmp rbx, [rel fptr wrt ..got] ; check if pointing fptr or lower
     jc .end
     mov rdi, format
     mov rsi, rbx
-    call printf
+    call printf wrt ..plt
     mov rbx, [rbx]
     jmp .loop 
 


### PR DESCRIPTION
I was getting linker errors when linking the latest listing code for 16-2 with gcc. Required adding missing references to GOT and PLT, which I've added to the assembly source file.