### PR TITLE
Two proposed corrections to text

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -156,6 +156,14 @@ Should be:
 
 Both `0branch` and `branch` are compile-only.
 
+### Page 130, Section 8.1
+
+**Warnings are errors** it is very bad practice to ship code that ~~does not~~ compiles with warnings. Warnings are emitted for a reason. Source code should always compile without any errors or warnings before it is shipped.
+
+### Page 133, Section 8.2
+
+**Static typing** means that all types are known ~~in~~ at compile time. There can be ~~absolutely incertitude~~ absolute certainty about data types.
+
 ### Page 137, Section 8.3.5 
 
 Then, as the break is not ending this case, after executing the first


### PR DESCRIPTION
Thanks for a great book!  Just spotted these possible errors....  Happy to provide more if I spot them, and they are welcome as part of the books errata ?

Suggested corrections are:

### Page 130, Section 8.1

**Warnings are errors** it is very bad practice to ship code that ~~does not~~ compiles with warnings. Warnings are emitted for a reason. Source code should always compile without any errors or warnings before it is shipped.

**Reason for suggested change:** the logic of the statement in the book is backwards. I assume it is meant to say that any code should not be shipped unless it has had corrections applied first, so any compile time warnings are fixed and therefore removed. As well as the correction, I have added an additional sentence to reinforce the point, if that is what is meant?

### Page 133, Section 8.2

**Static typing** means that all types are known ~~in~~ at compile time. There can be ~~absolutely incertitude~~ absolute certainty about data types.

**Reason for suggested change:** Should read 'at compile time' not 'in compile time'. So at the point of compilation the types should all be defined and known.  Use of '_absolutely incertitude_' is not what is meant here? It should state that static typing provides 'absolute certainty' as the static (ie unmovable) types are defined and therefore fixed in the source code, providing 'absolute certainty' of their purpose. Hope that's right :)