### PR TITLE
Fix Segmentation Fault in chap2/endianness

### DIFF
--- a/listings/chap2/endianness/endianness.asm
+++ b/listings/chap2/endianness/endianness.asm
@@ -3,7 +3,8 @@ section .data
 newline_char: db 10
 codes: db '0123456789abcdef'
 global _start                       
-                                     
+
+section .text
 
 print_newline:
     mov rax, 1


### PR DESCRIPTION
The instructions for the functions are defined in a `.data` section, which results in a segmentation fault. Marking the section as `.text` resolves the issue.